### PR TITLE
22 hide footer

### DIFF
--- a/components/common/Footer/Footer.tsx
+++ b/components/common/Footer/Footer.tsx
@@ -31,27 +31,26 @@ const Footer: FC<Props> = ({ className, pages }) => {
                 <span className="rounded-full border border-gray-700 mr-2">
                   <Logo />
                 </span>
-                <span>ACME</span>
               </a>
             </Link>
           </div>
           <div className="col-span-1 lg:col-span-2">
-            <ul className="flex flex-initial flex-col md:flex-1">
-              <li className="py-3 md:py-0 md:pb-4">
+            <ul className="flex flex-initial flex-row md:flex-1">
+              <li className="px-3">
                 <Link href="/">
                   <a className="text-primary hover:text-accents-6 transition ease-in-out duration-150">
                     Home
                   </a>
                 </Link>
               </li>
-              <li className="py-3 md:py-0 md:pb-4">
+              <li className="px-3">
                 <Link href="/">
                   <a className="text-primary hover:text-accents-6 transition ease-in-out duration-150">
                     Careers
                   </a>
                 </Link>
               </li>
-              <li className="py-3 md:py-0 md:pb-4">
+              <li className="px-3">
                 <Link href="/blog">
                   <a className="text-primary hover:text-accents-6 transition ease-in-out duration-150">
                     Blog
@@ -82,34 +81,8 @@ const Footer: FC<Props> = ({ className, pages }) => {
               ))}
             </ul>
           </div>
-          <div className="col-span-1 lg:col-span-6 flex items-start lg:justify-end text-primary">
-            <div className="flex space-x-6 items-center h-10">
-              <a
-                aria-label="Github Repository"
-                href="https://github.com/vercel/commerce"
-                className={s.link}
-              >
-                <Github />
-              </a>
-              <I18nWidget />
-            </div>
-          </div>
         </div>
-        <div className="py-12 flex flex-col md:flex-row justify-between items-center space-y-4">
-          <div>
-            <span>&copy; 2020 ACME, Inc. All rights reserved.</span>
-          </div>
-          <div className="flex items-center">
-            <span className="text-primary">Crafted by</span>
-            <a href="https://vercel.com" aria-label="Vercel.com Link">
-              <img
-                src="/vercel.svg"
-                alt="Vercel.com Logo"
-                className="inline-block h-6 ml-4 text-primary"
-              />
-            </a>
-          </div>
-        </div>
+        
       </Container>
     </footer>
   )

--- a/components/common/Layout/Layout.tsx
+++ b/components/common/Layout/Layout.tsx
@@ -60,7 +60,7 @@ const Layout: FC<Props> = ({ children, pageProps }) => {
       <div className={cn(s.root)}>
         <Navbar />
         <main className="fit">{children}</main>
-        <Footer className="hidden" pages={pageProps.pages} />
+        <Footer pages={pageProps.pages} />
 
         <Sidebar open={displaySidebar} onClose={closeSidebar}>
           <CartSidebarView />


### PR DESCRIPTION
Footer now reads horizontally as opposed to vertically, and remove non-Merkatta elements 

![image](https://user-images.githubusercontent.com/12687406/102737540-8b3aa400-42fc-11eb-83c2-938df6e5d0fe.png)

![image](https://user-images.githubusercontent.com/12687406/102738126-0d779800-42fe-11eb-8c65-234eb110a5dd.png)

