### PR TITLE
Modal Background Cover All Elements

### DIFF
--- a/components/ui/Product/index.tsx
+++ b/components/ui/Product/index.tsx
@@ -110,7 +110,7 @@ const Products = () => {
       <div className="mb-12 transition ease-in duration-75" >
         <h1 className="flex-auto text-xl font-semibold">Products</h1>
         {!hideProductModal && (
-          <div className={"fixed z-10 inset-0 overflow-y-auto"}>
+          <div className={"fixed z-40 inset-0 overflow-y-auto"}>
           <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
             <div className="fixed inset-0 transition-opacity" aria-hidden="true">
               <div className="absolute inset-0 bg-gray-500 opacity-75"></div>


### PR DESCRIPTION
## Notes
- modal background covers all elements on screen when modal is presented

## Before
<img width="1792" alt="Screen Shot 2020-12-28 at 2 28 26 AM" src="https://user-images.githubusercontent.com/5482800/103208978-bef66a80-48b6-11eb-991f-d9ca83d28016.png">

## After
<img width="1792" alt="Screen Shot 2020-12-28 at 2 44 48 AM" src="https://user-images.githubusercontent.com/5482800/103208991-c7e73c00-48b6-11eb-98e7-37c7361c4a2c.png">
